### PR TITLE
fix Find-Next and Find-Previous command to behave like in eclipse

### DIFF
--- a/package.json
+++ b/package.json
@@ -266,7 +266,7 @@
                 "win": "ctrl+k",
                 "linux": "ctrl+k",
                 "key": "ctrl+k",
-                "command": "editor.action.nextSelectionMatchFindAction",
+                "command": "editor.action.nextMatchFindAction",
                 "when": "editorTextFocus"
             },
             {
@@ -274,7 +274,7 @@
                 "win": "ctrl+shift+k",
                 "linux": "ctrl+shift+k",
                 "key": "ctrl+shift+k",
-                "command": "editor.action.previousSelectionMatchFindAction",
+                "command": "editor.action.previousMatchFindAction",
                 "when": "editorTextFocus"
             },
             {


### PR DESCRIPTION
Hi,
if no text is selected, the Find-Next and Find-Previous command searches the token close to the cursor if no text is selected. In contrast, Eclipse uses always the last search term.