### PR TITLE
Added delete left and right navigation keybindings

### DIFF
--- a/package.json
+++ b/package.json
@@ -363,6 +363,22 @@
                 "when": "textInputFocus"
             },
             {
+                "mac": "alt+backspace",
+                "win": "ctrl+backspace",
+                "linux": "ctrl+backspace",
+                "key": "ctrl+backspace",
+                "command": "deleteWordPartLeft",
+                "when": "textInputFocus"
+            },
+            {
+                "mac": "alt+delete",
+                "win": "ctrl+delete",
+                "linux": "ctrl+delete",
+                "key": "ctrl+delete",
+                "command": "deleteWordPartRight",
+                "when": "textInputFocus"
+            },
+            {
                 "mac": "cmd+alt+left",
                 "win": "alt+left",
                 "linux": "alt+left",


### PR DESCRIPTION
I'm not terribly sure on the keybindings for Linux or Mac versions, so I just used the modifier keys from the keybindings above these two.  