### PR TITLE
New key binding for commenting lines: cntrl+7

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,6 +132,14 @@
                 "when": "editorTextFocus"
             },
             {
+                "mac": "cmd+7",
+                "win": "ctrl+7",
+                "linux": "ctrl+7",
+                "key": "ctrl+7",
+                "command": "editor.action.commentLine",
+                "when": "editorTextFocus"
+            },
+            {
                 "mac": "cmd+shift+/",
                 "win": "ctrl+shift+/",
                 "linux": "ctrl+shift+/",


### PR DESCRIPTION
Note, only tested on windows, not sure about linux or mac.
Issue #25