### PR TITLE
Open the active editors drop down list

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
                 "win": "ctrl+e",
                 "linux": "ctrl+e",
                 "key": "ctrl+e",
-                "command": "workbench.action.openPreviousRecentlyUsedEditorInGroup"
+                "command": "workbench.action.showEditorsInActiveGroup"
             },
             {
                 "mac": "cmd+shift+w",


### PR DESCRIPTION
Eclipse's **Open the editor drop down list** equivalent in VSCode is **View: Show Editors in Active Group By Most Recently Used** (`workbench.action.showEditorsInActiveGroup`).

Checked in VSCode:
```
Version: 1.43.2 (system setup)
Commit: 0ba0ca52957102ca3527cf479571617f0de6ed50
Date: 2020-03-24T07:38:38.248Z
Electron: 7.1.11
Chrome: 78.0.3904.130
Node.js: 12.8.1
V8: 7.8.279.23-electron.0
OS: Windows_NT x64 10.0.17134
```