### PR TITLE
Adding the "evaluate" shortcut

### DIFF
--- a/package.json
+++ b/package.json
@@ -440,6 +440,51 @@
                 "key": "ctrl+f2",
                 "command": "workbench.action.debug.stop",
                 "when": "inDebugMode"
+            },
+            {
+                "key": "ctrl+shift+i",
+                "command": "editor.debug.action.selectionToRepl",
+                "when": "inDebugMode"
+            },
+            {
+                "key": "ctrl+shift+i",
+                "command": "editor.action.formatDocument",
+                "when": "editorHasDocumentFormattingProvider && editorHasDocumentFormattingProvider && editorTextFocus && !editorReadonly && !inDebugMode"
+            },
+            {
+                "key": "ctrl+shift+i",
+                "command": "-editor.action.formatDocument",
+                "when": "editorHasDocumentFormattingProvider && editorHasDocumentFormattingProvider && editorTextFocus && !editorReadonly"
+            },
+            {
+                "key": "ctrl+shift+i",
+                "command": "editor.action.formatDocument.none",
+                "when": "editorTextFocus && !editorHasDocumentFormattingProvider && !editorHasDocumentFormattingProvider && !editorReadonly && !inDebugMode"
+            },
+            {
+                "key": "ctrl+shift+i",
+                "command": "-editor.action.formatDocument.none",
+                "when": "editorTextFocus && !editorHasDocumentFormattingProvider && !editorHasDocumentFormattingProvider && !editorReadonly"
+            },
+            {
+                "key": "ctrl+shift+i",
+                "command": "notebook.format",
+                "when": "!editorTextFocus && activeEditor == 'workbench.editor.notebook' && !inDebugMode"
+            },
+            {
+                "key": "ctrl+shift+i",
+                "command": "-notebook.format",
+                "when": "!editorTextFocus && activeEditor == 'workbench.editor.notebook'"
+            },
+            {
+                "key": "ctrl+shift+i",
+                "command": "workbench.action.toggleDevTools",
+                "when": "isDevelopment && !inDebugMode"
+            },
+            {
+                "key": "ctrl+shift+i",
+                "command": "-workbench.action.toggleDevTools",
+                "when": "isDevelopment"
             }
         ]
     },


### PR DESCRIPTION
Adding the evaluate shortcut and disabling the other references of the same shortcut in VSCode when in debug mode.