### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
                 "win": "ctrl+h",
                 "linux": "ctrl+h",
                 "key": "ctrl+h",
-                "command": "workbench.view.search"
+                "command": "workbench.action.findInFiles"
             },
             {
                 "mac": "cmd+shift+t",


### PR DESCRIPTION
this used to work and I am not sure how this changed, in eclipse `ctrl+h` does a search (and replace) in files

This is the recommended fix from VScode: https://github.com/microsoft/vscode/issues/120174#issuecomment-810252426