### PR TITLE
add "call hierarchy"

### DIFF
--- a/package.json
+++ b/package.json
@@ -455,6 +455,14 @@
                 "key": "ctrl+f2",
                 "command": "workbench.action.debug.stop",
                 "when": "inDebugMode"
+            },
+            {
+                "mac": "ctrl+alt+h",
+                "win": "ctrl+alt+h",
+                "linux": "ctrl+alt+h",
+                "key": "ctrl+alt+h",
+                "command": "references-view.showCallHierarchy",
+                "when": "editorHasCallHierarchyProvider"
             }
         ]
     },


### PR DESCRIPTION
Since "Show Call Hierarchy" is supported in [references-view](https://github.com/microsoft/vscode-references-view), which is the VSCode's build-in extension. We can add eclipse keybindings support for call hierarchy.