### PR TITLE
add keymap for type hierarchy

### DIFF
--- a/package.json
+++ b/package.json
@@ -463,6 +463,14 @@
                 "key": "ctrl+alt+h",
                 "command": "references-view.showCallHierarchy",
                 "when": "editorHasCallHierarchyProvider"
+            },
+            {
+                "mac": "f4",
+                "win": "f4",
+                "linux": "f4",
+                "key": "f4",
+                "command": "java.action.showTypeHierarchy",
+                "when": "editorLangId == java && editorTextFocus"
             }
         ]
     },


### PR DESCRIPTION
Since Type hierarchy has been [supported](https://github.com/redhat-developer/vscode-java/blob/master/CHANGELOG.md#0770-april-15th-2021) by Java extension, we can support it's keybinding here.