### PR TITLE
add keymap for "extract method"

### DIFF
--- a/package.json
+++ b/package.json
@@ -353,6 +353,17 @@
                 "when": "editorTextFocus"
             },
             {
+                "mac": "alt+cmd+m",
+                "win": "alt+shift+m",
+                "linux": "alt+shift+m",
+                "key": "alt+shift+m",
+                "command": "editor.action.codeAction",
+                "when": "editorTextFocus",
+                "args": {
+                    "kind": "refactor.extract.function"
+                }
+            },
+            {
                 "mac": "alt+left",
                 "win": "ctrl+left",
                 "linux": "ctrl+left",


### PR DESCRIPTION
we can support Refactor action "Extract to method" since it's available already. A reference can be found [here](https://code.visualstudio.com/docs/editor/refactoring#_extract-method).