### PR TITLE
Support split editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,6 +124,13 @@
                 "command": "workbench.action.focusActiveEditorGroup"
             },
             {
+                "mac": "cmd+shift+[",
+                "win": "ctrl+shift+[",
+                "linux": "ctrl+shift+[",
+                "key": "ctrl+shift+[",
+                "command": "workbench.action.splitEditor"
+            },
+            {
                 "mac": "cmd+shift+c",
                 "win": "ctrl+shift+c",
                 "linux": "ctrl+shift+c",


### PR DESCRIPTION
Eclipse:
![spliteditor](https://user-images.githubusercontent.com/45906942/158632889-ca519b57-6c68-43f1-8a7d-064c49d1337c.png)

VSCode:
![image](https://user-images.githubusercontent.com/45906942/158633028-88ccd296-7016-4828-947f-420587c6e233.png)
