### PR TITLE
Correct Debug and Support Run

### DIFF
--- a/package.json
+++ b/package.json
@@ -458,6 +458,14 @@
                 "when": "debuggersAvailable && debugState == 'inactive'"
             },
             {
+                "mac": "cmd+shift+f11",
+                "win": "ctrl+f11",
+                "linux": "ctrl+f11",
+                "key": "ctrl+f11",
+                "command": "workbench.action.debug.run",
+                "when": "debuggersAvailable && debugState != 'initializing'"
+            },
+            {
                 "mac": "f5",
                 "win": "f5",
                 "linux": "f5",

--- a/package.json
+++ b/package.json
@@ -450,12 +450,12 @@
                 "when": "inDebugMode"
             },
             {
-                "mac": "cmd+shift+f11",
-                "win": "ctrl+f11",
-                "linux": "ctrl+f11",
-                "key": "ctrl+f11",
+                "mac": "cmd+f11",
+                "win": "f11",
+                "linux": "f11",
+                "key": "f11",
                 "command": "workbench.action.debug.start",
-                "when": "!inDebugMode"
+                "when": "debuggersAvailable && debugState == 'inactive'"
             },
             {
                 "mac": "f5",


### PR DESCRIPTION
Current debug keybinding is wrong. The correct keybinding of eclipse default is `f11` in windows.

## Eclipse:
Debug:
![image](https://user-images.githubusercontent.com/45906942/158635895-05da9c3c-e550-49df-b6d3-c1f4f436c5d2.png)

Run:
![image](https://user-images.githubusercontent.com/45906942/158636678-999505aa-3dd7-4d44-8080-3242ac715532.png)

## VSCode:
Debug:
![image](https://user-images.githubusercontent.com/45906942/158635993-b4fe42be-ea7d-4983-8367-60d7f68b89a2.png)

Run:
![image](https://user-images.githubusercontent.com/45906942/158636920-ab23930d-7790-4a85-b881-cecae66856ea.png)
