### PR TITLE
Add support for jumping to matching bracket.

### DIFF
--- a/package.json
+++ b/package.json
@@ -558,6 +558,14 @@
                 "key": "alt+shift+up",
                 "command": "editor.action.smartSelect.expand",
                 "when": "editorTextFocus"
+            },
+            {
+                "mac": "cmd+shift+p",
+                "win": "ctrl+shift+p",
+                "linux": "ctrl+shift+p",
+                "key": "ctrl+shift+p",
+                "command": "editor.action.jumpToBracket",
+                "when": "editorTextFocus"
             }
         ]
     },


### PR DESCRIPTION
See https://github.com/eclipse-jdt/eclipse.jdt.ui/blob/0985e8f2d33355f6c6cac0dad0d23487a7070555/org.eclipse.jdt.ui/plugin.xml#L4849-L4853 , where https://github.com/eclipse-jdt/eclipse.jdt.ui/blob/0985e8f2d33355f6c6cac0dad0d23487a7070555/org.eclipse.jdt.ui/plugin.xml#L4442-L4443 .

Signed-off-by: Roland Grunberg <rgrunber@redhat.com>