### PR TITLE
Fix ctrl+m shortcut to hide all panels.

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
                 "win": "ctrl+m",
                 "linux": "ctrl+m",
                 "key": "ctrl+m",
-                "command": "workbench.action.toggleSidebarVisibility"
+                "command": "workbench.action.toggleZenMode"
             },
             {
                 "mac": "cmd+e",


### PR DESCRIPTION
Fixes #62 if you want.